### PR TITLE
chore: update repo URL references to reflect transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ The Nillion docs are built using [Docusaurus v3](https://docusaurus.io/). Docume
 
 ## Improving the docs
 
-Got a suggestion for improving the docs? Let us know by [creating a Github Issue](https://github.com/nillion-oss/nillion-docs/issues/new?assignees=&labels=documentation&projects=&template=improve-documentation.md&title=%5BDOCS%5D)
+Got a suggestion for improving the docs? Let us know by [creating a Github Issue](https://github.com/NillionNetwork/nillion-docs/issues/new?assignees=&labels=documentation&projects=&template=improve-documentation.md&title=%5BDOCS%5D)
 
 ## Asking questions
 
-Use our [Github Discussions forum](https://github.com/orgs/nillion-oss/discussions?discussions_q=) to ask technical questions and share ideas about Nillion.
+Use our [Github Discussions forum](https://github.com/orgs/NillionNetwork/discussions?discussions_q=) to ask technical questions and share ideas about Nillion.
 
 ## Running the docs locally
 

--- a/docs/community-and-support.md
+++ b/docs/community-and-support.md
@@ -10,11 +10,11 @@
 
 ### Developer questions and technical discussions
 
-Nillion's [Github Discussions](https://github.com/orgs/nillion-oss/discussions?discussions_q=) forum is our central developer hub for technical discussions related to Nillion. Builders can use Github discussions to share ideas, ask questions, showcase their projects, and stay updated on the latest news and announcements from the Nillion team.
+Nillion's [Github Discussions](https://github.com/orgs/NillionNetwork/discussions?discussions_q=) forum is our central developer hub for technical discussions related to Nillion. Builders can use Github discussions to share ideas, ask questions, showcase their projects, and stay updated on the latest news and announcements from the Nillion team.
 
 ### Improve the docs
 
-Got a suggestion for improving the docs? Let us know by [creating a Github Issue](https://github.com/nillion-oss/nillion-docs/issues/new?assignees=&labels=documentation&projects=&template=improve-documentation.md&title=%5BDOCS%5D).
+Got a suggestion for improving the docs? Let us know by [creating a Github Issue](https://github.com/NillionNetwork/nillion-docs/issues/new?assignees=&labels=documentation&projects=&template=improve-documentation.md&title=%5BDOCS%5D).
 
 ### How to open a support ticket
 

--- a/docs/compute.md
+++ b/docs/compute.md
@@ -10,7 +10,7 @@ Perform single or multi party computation using secrets stored in the network.
 
 ## Single Party Compute
 
-Single party compute involves only one Party that provides inputs and receives outputs of a program. Single party compute examples are available in the Python Starter Repo [client_single_party_compute folder](https://github.com/nillion-oss/nillion-python-starter/client_single_party_compute).
+Single party compute involves only one Party that provides inputs and receives outputs of a program. Single party compute examples are available in the Python Starter Repo [client_single_party_compute folder](https://github.com/NillionNetwork/nillion-python-starter/client_single_party_compute).
 
 ### Example: addition_simple.py
 
@@ -20,14 +20,14 @@ The addition_simple example is a single party compute example that adds two secr
   <TabItem value="client" label="Client code" default>
 
 ```python reference showGithubLink
-https://github.com/nillion-oss/nillion-python-starter/blob/main/client_single_party_compute/addition_simple.py#L14-L100
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/addition_simple.py#L14-L100
 ```
 
   </TabItem>
   <TabItem value="readme" label="Nada program" default>
 
 ```python reference showGithubLink
-https://github.com/nillion-oss/nillion-python-starter/blob/main/programs/addition_simple.py
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/programs/addition_simple.py
 
 ```
 
@@ -38,13 +38,13 @@ https://github.com/nillion-oss/nillion-python-starter/blob/main/programs/additio
 
 Multi party compute involves more than one Party. These Parties collaborate to provide secret inputs and one Party receives outputs of the program.
 
-The [client_multi_party_compute](https://github.com/nillion-oss/nillion-python-starter/blob/main/client_multi_party_compute) folder has a 3-step multi party compute example involving multiple parties providing secret inputs for computation of a program. The first party stores a secret, then N other parties store permissioned secrets giving the first party compute access. The first party computes with all secrets.
+The [client_multi_party_compute](https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_multi_party_compute) folder has a 3-step multi party compute example involving multiple parties providing secret inputs for computation of a program. The first party stores a secret, then N other parties store permissioned secrets giving the first party compute access. The first party computes with all secrets.
 
 <Tabs>
   <TabItem value="readme" label="README" default>
 
 ```python reference showGithubLink
-https://github.com/nillion-oss/nillion-python-starter/blob/main/client_multi_party_compute/README.md
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_multi_party_compute/README.md
 
 ```
 
@@ -52,7 +52,7 @@ https://github.com/nillion-oss/nillion-python-starter/blob/main/client_multi_par
   <TabItem value="config" label="Config file" default>
 
 ```python reference showGithubLink
-https://github.com/nillion-oss/nillion-python-starter/blob/main/client_multi_party_compute/config.py
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_multi_party_compute/config.py
 ```
 
   </TabItem>
@@ -60,7 +60,7 @@ https://github.com/nillion-oss/nillion-python-starter/blob/main/client_multi_par
     ### Step 1: 1st Party Stores a Secret
 
 ```python reference showGithubLink
-https://github.com/nillion-oss/nillion-python-starter/blob/main/client_multi_party_compute/01_store_secret_party1.py#L19-L100
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_multi_party_compute/01_store_secret_party1.py#L19-L100
 ```
 
   </TabItem>
@@ -68,7 +68,7 @@ https://github.com/nillion-oss/nillion-python-starter/blob/main/client_multi_par
     ### Step 2: N other parties store a permissioned secret
 
 ```python reference showGithubLink
-https://github.com/nillion-oss/nillion-python-starter/blob/main/client_multi_party_compute/02_store_secret_party_n.py#L36-L108
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_multi_party_compute/02_store_secret_party_n.py#L36-L108
 ```
 
   </TabItem>
@@ -76,7 +76,7 @@ https://github.com/nillion-oss/nillion-python-starter/blob/main/client_multi_par
     ### Step 3: The 1st Party computes with all secrets
 
 ```python reference showGithubLink
-https://github.com/nillion-oss/nillion-python-starter/blob/main/client_multi_party_compute/03_multi_party_compute.py#L43-L100
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_multi_party_compute/03_multi_party_compute.py#L43-L100
 ```
 
   </TabItem>

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -6,7 +6,7 @@ Grant other Nillion users permission to retrieve, update, or delete your secrets
 
 ## Setting permissions
 
-Permissions examples demonstrated modifying the permissions of secrets. Check out the [permissions](https://github.com/nillion-oss/nillion-python-starter/blob/main/permissions) folder on Github for examples of
+Permissions examples demonstrated modifying the permissions of secrets. Check out the [permissions](https://github.com/NillionNetwork/nillion-python-starter/blob/main/permissions) folder on Github for examples of
 
 - storing a permissioned secret
 - retrieving a secret

--- a/docs/python-client-examples.md
+++ b/docs/python-client-examples.md
@@ -4,6 +4,6 @@ import DocCardList from '@theme/DocCardList';
 
 ## Nillion Python Starter Repo
 
-The [Nillion Python Starter Repo](https://github.com/nillion-oss/nillion-python-starter) used in the [Developer Quickstart](quickstart) contains single party compute examples, multi party compute examples, and examples involving secret permissions.
+The [Nillion Python Starter Repo](https://github.com/NillionNetwork/nillion-python-starter) used in the [Developer Quickstart](quickstart) contains single party compute examples, multi party compute examples, and examples involving secret permissions.
 
 <DocCardList />

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,7 @@ import DownloadSDK from '@site/src/components/DownloadSDK/downloadSDK';
 Start building on Nillion. This quickstart will walk you through
 
 1. Installing the Nillion SDK
-2. Setting up a developer environment with [nillion-python-starter](https://github.com/nillion-oss/nillion-python-starter)
+2. Setting up a developer environment with [nillion-python-starter](https://github.com/NillionNetwork/nillion-python-starter)
 3. Running a local network (cluster of nodes)
 4. Writing your first Nada program
 5. Connecting to the network with NillionClient to store secrets, store programs, and compute on programs with stored secrets
@@ -171,10 +171,10 @@ Download the PyNada DSL binaries and Python Client binaries. Save these in the v
 
 ## Clone the Nillion python starter repo
 
-The [Nillion Python Starter](https://github.com/nillion-oss/nillion-python-starter) repo has everything you need to start building. Clone the repo:
+The [Nillion Python Starter](https://github.com/NillionNetwork/nillion-python-starter) repo has everything you need to start building. Clone the repo:
 
 ```bash
-git clone https://github.com/nillion-oss/nillion-python-starter.git
+git clone https://github.com/NillionNetwork/nillion-python-starter.git
 cd nillion-python-starter
 ```
 
@@ -212,7 +212,7 @@ Update the following SDK path variables within your .env
 - `NILLION_PYCLIENT_WHL_FILE_NAME` with the file name of your Python Client binaries. This is a py_nillion_client .whl file inside of NILLION_WHL_ROOT
 
 ```yaml reference showGithubLink
-https://github.com/nillion-oss/nillion-python-starter/blob/main/.env.sample#L3-L11
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/.env.sample#L3-L11
 ```
 
 <!-- :::tip
@@ -257,7 +257,7 @@ killall run-local-cluster
 The Nillion Network uses [Nada](nada-lang-framework), our MPC language, to define MPC programs. The first implementation of Nada is a Python DSL (Domain Specific Language), called PyNada. Let’s write a tiny Nada program that adds 2 secret numbers. Here’s the code for the finished program we’ll write line by line:
 
 ```python reference showGithubLink
-https://github.com/nillion-oss/nillion-python-starter/blob/main/programs/tiny_secret_addition_complete.py
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/programs/tiny_secret_addition_complete.py
 ```
 
 Create a python file for the Nada program in the programs folder
@@ -440,7 +440,7 @@ Open the `client_single_party_compute/tiny_secret_addition.py` file. This file c
 ### Review secret storage code
 
 ```yaml reference showGithubLink
-https://github.com/nillion-oss/nillion-python-starter/blob/main/client_single_party_compute/addition_simple.py#L15-L38
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/addition_simple.py#L15-L38
 ```
 
 When a secret is stored, the network returns its store_id.
@@ -452,7 +452,7 @@ The second half of the `client_single_party_compute/tiny_secret_addition.py` exa
 ### Review full example
 
 ```yaml reference showGithubLink
-https://github.com/nillion-oss/nillion-python-starter/blob/main/client_single_party_compute/addition_simple.py#L15-L100
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/addition_simple.py#L15-L100
 ```
 
 ### Run the example
@@ -472,9 +472,9 @@ You've successfully written your first single party Nada program, stored it on a
 
 - running other examples
 
-  - single party program examples in the [client_single_party_compute folder](https://github.com/nillion-oss/nillion-python-starter/tree/main/client_single_party_compute)
-  - multi party examples in the [client_multi_party_compute folder](https://github.com/nillion-oss/nillion-python-starter/tree/main/client_multi_party_compute)
-  - permissioning secrets examples in the in the [permissions folder](https://github.com/nillion-oss/nillion-python-starter/tree/main/permissions) for storing and retrieving permissioned secrets and revoking permissions
+  - single party program examples in the [client_single_party_compute folder](https://github.com/NillionNetwork/nillion-python-starter/tree/main/client_single_party_compute)
+  - multi party examples in the [client_multi_party_compute folder](https://github.com/NillionNetwork/nillion-python-starter/tree/main/client_multi_party_compute)
+  - permissioning secrets examples in the in the [permissions folder](https://github.com/NillionNetwork/nillion-python-starter/tree/main/permissions) for storing and retrieving permissioned secrets and revoking permissions
 
 - reading about [Nillion concepts](/concepts) and the [Nada-lang framework](nada-lang-framework)
 

--- a/docs/retrieve-secret.md
+++ b/docs/retrieve-secret.md
@@ -11,7 +11,7 @@ Retrieve secret strings, integers, and arrays from the network.
 Retrieve and decode a stored secret string
 
 ```python reference showGithubLink
-https://github.com/nillion-oss/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_blob.py#L39-L45
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_blob.py#L39-L45
 ```
 
 ## Retrieve a SecretInteger
@@ -19,7 +19,7 @@ https://github.com/nillion-oss/nillion-python-starter/blob/main/store_and_retrie
 Retrieve a stored secret integer
 
 ```python reference showGithubLink
-https://github.com/nillion-oss/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_integer.py#L37-L41
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_integer.py#L37-L41
 ```
 
 ## Retrieve a SecretArray
@@ -27,5 +27,5 @@ https://github.com/nillion-oss/nillion-python-starter/blob/main/store_and_retrie
 Retrieve a stored secret array of integers
 
 ```python reference showGithubLink
-https://github.com/nillion-oss/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_array.py#L45-L60
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_array.py#L45-L60
 ```

--- a/docs/store-secrets.md
+++ b/docs/store-secrets.md
@@ -9,7 +9,7 @@ Check out the [store_secrets](https://docs.nillion.com/pydocs/client#py_nillion_
 Store a SecretBlob, a UTF-8 encoded secret string
 
 ```python reference showGithubLink
-https://github.com/nillion-oss/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_blob.py#L15-L39
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_blob.py#L15-L39
 ```
 
 ## Store a SecretInteger
@@ -17,7 +17,7 @@ https://github.com/nillion-oss/nillion-python-starter/blob/main/store_and_retrie
 Store a single SecretInteger
 
 ```python reference showGithubLink
-https://github.com/nillion-oss/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_integer.py#L15-L37
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_integer.py#L15-L37
 ```
 
 ## Store a SecretArray
@@ -25,5 +25,5 @@ https://github.com/nillion-oss/nillion-python-starter/blob/main/store_and_retrie
 Stores an array, a list of values with the SecretInteger type
 
 ```python reference showGithubLink
-https://github.com/nillion-oss/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_array.py#L15-L45
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_array.py#L15-L45
 ```

--- a/docs/technical-reports-and-demos.md
+++ b/docs/technical-reports-and-demos.md
@@ -13,13 +13,13 @@ description: >-
 * [Technical Report on Threshold ECDSA in the Preprocessing Setup](https://nillion.pub/threshold-ecdsa-preprocessing-setup.pdf)
 * [More efficient comparison protocols for MPC](https://eprint.iacr.org/2023/1934.pdf)
 
-All technical reports are also available [on Github](https://github.com/nillion-oss/nillion-oss.github.io)
+All technical reports are also available [on Github](https://github.com/NillionNetwork/nillionnetwork.github.io)
 
 ### Implementation examples and demos
 
 | Topic                                                   | Implementation Example                                                         | Demo                                                                                          |
 | ------------------------------------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| Nillion's secure multi-party computation (MPC) protocol | [tinynmc library](https://github.com/nillion-oss/tinynmc)                      | -                                                                                             |
-| Multifactor Authentication (MFA)                        | [tinybio python library](https://github.com/nillion-oss/tinybio) using tinynmc | [tinybio: a secure decentralized biometric authentication demo](https://nillion.pub/tinybio/) |
-| Signatures (Threshold ECDSA)                            | [tinysig python library](https://github.com/nillion-oss/tinysig) using tinynmc | -                                                                                             |
-| Secure Auctions                                         | [tinybid python library](https://github.com/nillion-oss/tinybid) using tinynmc | [tinybid: a secure single-item first-price auction demo](https://nillion.pub/tinybid/)        |
+| Nillion's secure multi-party computation (MPC) protocol | [tinynmc library](https://github.com/NillionNetwork/tinynmc)                      | -                                                                                             |
+| Multifactor Authentication (MFA)                        | [tinybio python library](https://github.com/NillionNetwork/tinybio) using tinynmc | [tinybio: a secure decentralized biometric authentication demo](https://nillion.pub/tinybio/) |
+| Signatures (Threshold ECDSA)                            | [tinysig python library](https://github.com/NillionNetwork/tinysig) using tinynmc | -                                                                                             |
+| Secure Auctions                                         | [tinybid python library](https://github.com/NillionNetwork/tinybid) using tinynmc | [tinybid: a secure single-item first-price auction demo](https://nillion.pub/tinybid/)        |

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -62,7 +62,7 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           // editUrl:
-          //   'https://github.com/nillion-oss/nillion-docs/',
+          //   'https://github.com/NillionNetwork/nillion-docs/',
         },
         blog: false,
         theme: {
@@ -84,7 +84,7 @@ const config = {
         },
         items: [
           {
-            href: 'https://github.com/nillion-oss',
+            href: 'https://github.com/NillionNetwork',
             label: 'GitHub',
             position: 'right',
           },

--- a/sidebars.js
+++ b/sidebars.js
@@ -89,7 +89,7 @@ const sidebars = {
                 {
                   type: 'link',
                   label: 'Permissions Examples',
-                  href: 'https://github.com/nillion-oss/nillion-python-starter/tree/main/permissions',
+                  href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/main/permissions',
                 },
               ],
             },
@@ -105,12 +105,12 @@ const sidebars = {
                 {
                   type: 'link',
                   label: 'Single Party Examples',
-                  href: 'https://github.com/nillion-oss/nillion-python-starter/tree/main/client_single_party_compute',
+                  href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/main/client_single_party_compute',
                 },
                 {
                   type: 'link',
                   label: 'Multi Party Examples',
-                  href: 'https://github.com/nillion-oss/nillion-python-starter/tree/main/client_multi_party_compute',
+                  href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/main/client_multi_party_compute',
                 },
               ],
             },
@@ -134,7 +134,7 @@ const sidebars = {
         {
           type: 'link',
           label: 'Nada Program Examples',
-          href: 'https://github.com/nillion-oss/nillion-python-starter/tree/main/programs',
+          href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/main/programs',
         },
       ],
     },
@@ -167,7 +167,7 @@ const sidebars = {
     {
       type: 'link',
       label: 'Github',
-      href: 'https://github.com/nillion-oss',
+      href: 'https://github.com/NillionNetwork',
     },
     {
       type: 'link',


### PR DESCRIPTION
as part of the transfer of repositories over to the NillionNetwork GitHub org, these changes reflect the URL updates. there are already redirects in place, however it's best to align with the updated URLs.

please ensure thorough checks are done on all conceivable URLs that can be surmised from the diffs on the vercel preview site for this PR as part of the review