### PR TITLE
chore: Update nilup curl URL to include install.sh

### DIFF
--- a/docs/_sdk-installation.mdx
+++ b/docs/_sdk-installation.mdx
@@ -1,7 +1,7 @@
 1. Install [nilup](/nilup) the [Nillion SDK tool](/nillion-sdk-and-tools#nillion-sdk-tools) installer and version manager.
 
    ```bash
-   curl https://nilup.nilogy.xyz | bash
+   curl https://nilup.nilogy.xyz/install.sh | bash
    ```
 
    Confirm global `nilup` tool installation

--- a/docs/nilup.md
+++ b/docs/nilup.md
@@ -2,7 +2,7 @@
 
 `nilup` is an installer and version manager for the Nillion SDK
 
-To install `nilup`, run: `curl https://nilup.nilogy.xyz | bash`
+To install `nilup`, run: `curl https://nilup.nilogy.xyz/install.sh | bash`
 
 If you install the Nillion SDK using `nilup`, all the Nillion SDK commands will be managed by `nilup`,
 which will pick the version to use based on the next order, from highest to lowest priority: 


### PR DESCRIPTION
This commit changes the URL used to instruct users to install nilup to include the /install.sh path. Even though the root path (/) is essentially an alias for /install.sh, we shouldn't lock ourselves into that forever being the case.