### PR TITLE
Update docs to include a note about piping to bash for security-conscious folk

### DIFF
--- a/docs/_sdk-installation.mdx
+++ b/docs/_sdk-installation.mdx
@@ -1,5 +1,8 @@
 1. Install [nilup](/nilup) the [Nillion SDK tool](/nillion-sdk-and-tools#nillion-sdk-tools) installer and version manager.
 
+   _For the security-conscious, please download the `install.sh` script, so that you can inspect how
+   it works, before piping it to `bash`._
+
    ```bash
    curl https://nilup.nilogy.xyz/install.sh | bash
    ```

--- a/docs/js-quickstart.md
+++ b/docs/js-quickstart.md
@@ -29,6 +29,10 @@ git clone https://github.com/NillionNetwork/scaffold-nillion.git
 Before you use [Scaffold-Nillion](https://github.com/NillionNetwork/scaffold-nillion), you need to install the following tools:
 
 - `nilup`, an installer and version manager for the [Nillion SDK tools](https://docs.nillion.com/nillion-sdk-and-tools). Install nilup:
+
+_For the security-conscious, please download the `install.sh` script, so that you can inspect how
+it works, before piping it to `bash`._
+
   ```
   curl https://nilup.nilogy.xyz | bash
   ```

--- a/docs/js-quickstart.md
+++ b/docs/js-quickstart.md
@@ -34,7 +34,7 @@ _For the security-conscious, please download the `install.sh` script, so that yo
 it works, before piping it to `bash`._
 
   ```
-  curl https://nilup.nilogy.xyz | bash
+  curl https://nilup.nilogy.xyz/install.sh | bash
   ```
   - Confirm `nilup` installation
     ```

--- a/docs/nilup.md
+++ b/docs/nilup.md
@@ -2,7 +2,14 @@
 
 `nilup` is an installer and version manager for the Nillion SDK
 
-To install `nilup`, run: `curl https://nilup.nilogy.xyz/install.sh | bash`
+To install `nilup`, run:
+
+_For the security-conscious, please download the `install.sh` script, so that you can inspect how it
+works, before piping it to `bash`._
+
+```
+curl https://nilup.nilogy.xyz/install.sh | bash
+```
 
 If you install the Nillion SDK using `nilup`, all the Nillion SDK commands will be managed by `nilup`,
 which will pick the version to use based on the next order, from highest to lowest priority: 


### PR DESCRIPTION
This PR updates our nilup install documentation to include a note for security-conscious folk to inspect the install.sh script before piping it to bash to make sure they know we are not trying to hide anything and that we support their possible hesitation around blindly running commands from the internet in their terminals.