### PR TITLE
fix(JS): update user_id and party_id being attributes and not methods

### DIFF
--- a/docs/js-client-reference.md
+++ b/docs/js-client-reference.md
@@ -176,7 +176,7 @@ Permissions
 
 ## Example
 
-    permissions = nillion.Permissions.default_for_user(client.user_id())
+    permissions = nillion.Permissions.default_for_user(client.user_id)
 
 ### Parameters
 
@@ -562,7 +562,7 @@ The value must be a valid string representation of an unsigned integer.
 
 Secret
 
-## party_id()
+## party_id
 
 Get party_id property
 
@@ -786,7 +786,7 @@ The unique identifier of the update operation
 
 Promise.&lt;string&gt;
 
-## user_id()
+## user_id
 
 Get the user ID of the Client instance.
 


### PR DESCRIPTION
This PR updates user_id and party_id being attributes and not methods in the JS client (updated in https://github.com/NillionNetwork/nillion/pull/1430)