### PR TITLE
Examples restructure for nillion-python-client files

### DIFF
--- a/docs/compute.md
+++ b/docs/compute.md
@@ -20,7 +20,7 @@ The addition_simple example is a single party compute example that adds two secr
   <TabItem value="client" label="Client code" default>
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/addition_simple.py#L14-L100
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/addition_simple.py#L14-L100
 ```
 
   </TabItem>
@@ -38,13 +38,13 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/main/programs/addi
 
 Multi party compute involves more than one Party. These Parties collaborate to provide secret inputs and one Party receives outputs of the program.
 
-The [core_concept_multi_party_compute](https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_multi_party_compute) folder has a 3-step multi party compute example involving multiple parties providing secret inputs for computation of a program. The first party stores a secret, then N other parties store permissioned secrets giving the first party compute access. The first party computes with all secrets.
+The [core_concept_multi_party_compute](https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_multi_party_compute) folder has a 3-step multi party compute example involving multiple parties providing secret inputs for computation of a program. The first party stores a secret, then N other parties store permissioned secrets giving the first party compute access. The first party computes with all secrets.
 
 <Tabs>
   <TabItem value="readme" label="README" default>
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_multi_party_compute/README.md
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_multi_party_compute/README.md
 
 ```
 
@@ -52,7 +52,7 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/e
   <TabItem value="config" label="Config file" default>
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_multi_party_compute/config.py
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_multi_party_compute/config.py
 ```
 
   </TabItem>
@@ -60,7 +60,7 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/e
     ### Step 1: 1st Party Stores a Secret
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_multi_party_compute/01_store_secret_party1.py#L19-L100
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_multi_party_compute/01_store_secret_party1.py#L19-L100
 ```
 
   </TabItem>
@@ -68,7 +68,7 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/e
     ### Step 2: N other parties store a permissioned secret
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_multi_party_compute/02_store_secret_party_n.py#L36-L108
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_multi_party_compute/02_store_secret_party_n.py#L36-L108
 ```
 
   </TabItem>
@@ -76,7 +76,7 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/e
     ### Step 3: The 1st Party computes with all secrets
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_multi_party_compute/03_multi_party_compute.py#L43-L100
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_multi_party_compute/03_multi_party_compute.py#L43-L100
 ```
 
   </TabItem>

--- a/docs/compute.md
+++ b/docs/compute.md
@@ -10,7 +10,7 @@ Perform single or multi party computation using secrets stored in the network.
 
 ## Single Party Compute
 
-Single party compute involves only one Party that provides inputs and receives outputs of a program. Single party compute examples are available in the Python Starter Repo [client_single_party_compute folder](https://github.com/NillionNetwork/nillion-python-starter/client_single_party_compute).
+Single party compute involves only one Party that provides inputs and receives outputs of a program. Single party compute examples are available in the Python Starter Repo [core_concept_single_party_compute folder](https://github.com/NillionNetwork/nillion-python-starter/core_concept_single_party_compute).
 
 ### Example: addition_simple.py
 
@@ -20,7 +20,7 @@ The addition_simple example is a single party compute example that adds two secr
   <TabItem value="client" label="Client code" default>
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/addition_simple.py#L14-L100
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/addition_simple.py#L14-L100
 ```
 
   </TabItem>
@@ -38,13 +38,13 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/main/programs/addi
 
 Multi party compute involves more than one Party. These Parties collaborate to provide secret inputs and one Party receives outputs of the program.
 
-The [client_multi_party_compute](https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_multi_party_compute) folder has a 3-step multi party compute example involving multiple parties providing secret inputs for computation of a program. The first party stores a secret, then N other parties store permissioned secrets giving the first party compute access. The first party computes with all secrets.
+The [core_concept_multi_party_compute](https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_multi_party_compute) folder has a 3-step multi party compute example involving multiple parties providing secret inputs for computation of a program. The first party stores a secret, then N other parties store permissioned secrets giving the first party compute access. The first party computes with all secrets.
 
 <Tabs>
   <TabItem value="readme" label="README" default>
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_multi_party_compute/README.md
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_multi_party_compute/README.md
 
 ```
 
@@ -52,7 +52,7 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_multi_
   <TabItem value="config" label="Config file" default>
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_multi_party_compute/config.py
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_multi_party_compute/config.py
 ```
 
   </TabItem>
@@ -60,7 +60,7 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_multi_
     ### Step 1: 1st Party Stores a Secret
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_multi_party_compute/01_store_secret_party1.py#L19-L100
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_multi_party_compute/01_store_secret_party1.py#L19-L100
 ```
 
   </TabItem>
@@ -68,7 +68,7 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_multi_
     ### Step 2: N other parties store a permissioned secret
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_multi_party_compute/02_store_secret_party_n.py#L36-L108
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_multi_party_compute/02_store_secret_party_n.py#L36-L108
 ```
 
   </TabItem>
@@ -76,7 +76,7 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_multi_
     ### Step 3: The 1st Party computes with all secrets
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_multi_party_compute/03_multi_party_compute.py#L43-L100
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_multi_party_compute/03_multi_party_compute.py#L43-L100
 ```
 
   </TabItem>

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -6,7 +6,7 @@ Grant other Nillion users permission to retrieve, update, or delete your secrets
 
 ## Setting permissions
 
-Permissions examples demonstrated modifying the permissions of secrets. Check out the [permissions](https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_permissions) folder on Github for examples of
+Permissions examples demonstrated modifying the permissions of secrets. Check out the [permissions](https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_permissions) folder on Github for examples of
 
 - storing a permissioned secret
 - retrieving a secret

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -6,7 +6,7 @@ Grant other Nillion users permission to retrieve, update, or delete your secrets
 
 ## Setting permissions
 
-Permissions examples demonstrated modifying the permissions of secrets. Check out the [permissions](https://github.com/NillionNetwork/nillion-python-starter/blob/main/permissions) folder on Github for examples of
+Permissions examples demonstrated modifying the permissions of secrets. Check out the [permissions](https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_permissions) folder on Github for examples of
 
 - storing a permissioned secret
 - retrieving a secret

--- a/docs/python-quickstart.md
+++ b/docs/python-quickstart.md
@@ -117,11 +117,11 @@ Let's write a Python script that will interact with nillion-devnet. This Python 
 7. Compute on the program with 1st secret from the network, and the 2nd secret, provided at compute time
 8. Print the computation result
 
-Check out the completed Python script [here](https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py)
+Check out the completed Python script [here](https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py)
 
 ### Complete the python script 🎯 TODOs
 
-Open the [core_concept_single_party_compute/tiny_secret_addition.py](https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py) file and let's work through the 🎯 TODOs.
+Open the [core_concept_single_party_compute/tiny_secret_addition.py](https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py) file and let's work through the 🎯 TODOs.
 
 :::tip
 
@@ -136,12 +136,12 @@ The first step was completed for you. The script uses a `create_nillion_client` 
 <Tabs>
   <TabItem value="todo-1" label="Todo #1" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L14-L24
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L14-L24
 ```
   </TabItem>
   <TabItem value="complete-1" label="Complete #1" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L14-L24
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L14-L24
 ```
   </TabItem>
   <TabItem value="nillion-client" label="create_nillion_client helper" default>
@@ -156,12 +156,12 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/main/helpers/nilli
 <Tabs>
   <TabItem value="todo-1" label="Todo #2" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L26-L28
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L26-L28
 ```
   </TabItem>
   <TabItem value="complete-1" label="Complete #2" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L26-L29
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L26-L29
 ```
   </TabItem>
 </Tabs>
@@ -171,12 +171,12 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/e
 <Tabs>
   <TabItem value="todo-3" label="Todo #3" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L29-L37
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L29-L37
 ```
   </TabItem>
   <TabItem value="complete-3" label="Complete #3" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L30-L44
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L30-L44
 ```
   </TabItem>
 </Tabs>
@@ -186,12 +186,12 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/e
 <Tabs>
   <TabItem value="todo-4" label="Todo #4" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L38-L44
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L38-L44
 ```
   </TabItem>
   <TabItem value="complete-4" label="Complete #4" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L45-L58
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L45-L58
 ```
   </TabItem>
 </Tabs>
@@ -203,12 +203,12 @@ When we wrote our Nada program, we created 2 secret integers that are inputs to 
 <Tabs>
   <TabItem value="todo-5" label="Todo #5" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L45-L47
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L45-L47
 ```
   </TabItem>
   <TabItem value="complete-5" label="Complete #5" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L59-L65
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L59-L65
 ```
   </TabItem>
 </Tabs>
@@ -218,12 +218,12 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/e
 <Tabs>
   <TabItem value="todo-6" label="Todo #6" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L48-L50
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L48-L50
 ```
   </TabItem>
   <TabItem value="complete-6" label="Complete #6" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L66-L70
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L66-L70
 ```
   </TabItem>
 </Tabs>
@@ -233,12 +233,12 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/e
 <Tabs>
   <TabItem value="todo-7" label="Todo #7" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L51-L54
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L51-L54
 ```
   </TabItem>
   <TabItem value="complete-7" label="Complete #7" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L71-L84
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L71-L84
 ```
   </TabItem>
 </Tabs>
@@ -248,12 +248,12 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/e
 <Tabs>
   <TabItem value="todo-8" label="Todo #8" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L55-L56
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L55-L56
 ```
   </TabItem>
   <TabItem value="complete-8" label="Complete #8" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L85-L93
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L85-L93
 ```
   </TabItem>
 </Tabs>
@@ -275,14 +275,14 @@ You've successfully written your first single party Nada program, stored the pro
 
 - running other examples
 
-  - single party program examples in the [core_concept_single_party_compute folder](https://github.com/NillionNetwork/nillion-python-starter/tree/dave-restructure/examples_and_tutorials/core_concept_single_party_compute)
-  - multi party examples in the [core_concept_multi_party_compute folder](https://github.com/NillionNetwork/nillion-python-starter/tree/dave-restructure/examples_and_tutorials/core_concept_multi_party_compute)
-  - permissioning secrets examples in the in the [permissions folder](https://github.com/NillionNetwork/nillion-python-starter/tree/dave-restructure/examples_and_tutorials/core_concept_permissions) for storing and retrieving permissioned secrets and revoking permissions
+  - single party program examples in the [core_concept_single_party_compute folder](https://github.com/NillionNetwork/nillion-python-starter/tree/main/examples_and_tutorials/core_concept_single_party_compute)
+  - multi party examples in the [core_concept_multi_party_compute folder](https://github.com/NillionNetwork/nillion-python-starter/tree/main/examples_and_tutorials/core_concept_multi_party_compute)
+  - permissioning secrets examples in the in the [permissions folder](https://github.com/NillionNetwork/nillion-python-starter/tree/main/examples_and_tutorials/core_concept_permissions) for storing and retrieving permissioned secrets and revoking permissions
 
 - reading about [Nillion concepts](/concepts) and the [Nada Language](nada-lang)
 
 - learning how to interact with and manage programs, secrets, and permissions on the Nillion Network with [Nillion Client](/nillion-client)
-- solving the [millionaires problem](/multi-party-computation#classic-scenario-the-millionaires-problem) in the [millionaires_problem_example folder](https://github.com/NillionNetwork/nillion-python-starter/tree/dave-restructure/examples_and_tutorials/millionaires_problem_example)
+- solving the [millionaires problem](/multi-party-computation#classic-scenario-the-millionaires-problem) in the [millionaires_problem_example folder](https://github.com/NillionNetwork/nillion-python-starter/tree/main/examples_and_tutorials/millionaires_problem_example)
 
 ### Solve the millionaires problem
 

--- a/docs/python-quickstart.md
+++ b/docs/python-quickstart.md
@@ -117,11 +117,11 @@ Let's write a Python script that will interact with nillion-devnet. This Python 
 7. Compute on the program with 1st secret from the network, and the 2nd secret, provided at compute time
 8. Print the computation result
 
-Check out the completed Python script [here](https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition_complete.py)
+Check out the completed Python script [here](https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py)
 
 ### Complete the python script 🎯 TODOs
 
-Open the [client_single_party_compute/tiny_secret_addition.py](https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition.py) file and let's work through the 🎯 TODOs.
+Open the [core_concept_single_party_compute/tiny_secret_addition.py](https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py) file and let's work through the 🎯 TODOs.
 
 :::tip
 
@@ -136,12 +136,12 @@ The first step was completed for you. The script uses a `create_nillion_client` 
 <Tabs>
   <TabItem value="todo-1" label="Todo #1" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition.py#L14-L24
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L14-L24
 ```
   </TabItem>
   <TabItem value="complete-1" label="Complete #1" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition_complete.py#L14-L24
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L14-L24
 ```
   </TabItem>
   <TabItem value="nillion-client" label="create_nillion_client helper" default>
@@ -156,12 +156,12 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/main/helpers/nilli
 <Tabs>
   <TabItem value="todo-1" label="Todo #2" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition.py#L26-L28
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L26-L28
 ```
   </TabItem>
   <TabItem value="complete-1" label="Complete #2" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition_complete.py#L26-L29
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L26-L29
 ```
   </TabItem>
 </Tabs>
@@ -171,12 +171,12 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single
 <Tabs>
   <TabItem value="todo-3" label="Todo #3" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition.py#L29-L37
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L29-L37
 ```
   </TabItem>
   <TabItem value="complete-3" label="Complete #3" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition_complete.py#L30-L44
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L30-L44
 ```
   </TabItem>
 </Tabs>
@@ -186,12 +186,12 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single
 <Tabs>
   <TabItem value="todo-4" label="Todo #4" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition.py#L38-L44
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L38-L44
 ```
   </TabItem>
   <TabItem value="complete-4" label="Complete #4" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition_complete.py#L45-L58
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L45-L58
 ```
   </TabItem>
 </Tabs>
@@ -203,12 +203,12 @@ When we wrote our Nada program, we created 2 secret integers that are inputs to 
 <Tabs>
   <TabItem value="todo-5" label="Todo #5" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition.py#L45-L47
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L45-L47
 ```
   </TabItem>
   <TabItem value="complete-5" label="Complete #5" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition_complete.py#L59-L65
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L59-L65
 ```
   </TabItem>
 </Tabs>
@@ -218,12 +218,12 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single
 <Tabs>
   <TabItem value="todo-6" label="Todo #6" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition.py#L48-L50
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L48-L50
 ```
   </TabItem>
   <TabItem value="complete-6" label="Complete #6" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition_complete.py#L66-L70
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L66-L70
 ```
   </TabItem>
 </Tabs>
@@ -233,12 +233,12 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single
 <Tabs>
   <TabItem value="todo-7" label="Todo #7" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition.py#L51-L54
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L51-L54
 ```
   </TabItem>
   <TabItem value="complete-7" label="Complete #7" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition_complete.py#L71-L84
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L71-L84
 ```
   </TabItem>
 </Tabs>
@@ -248,12 +248,12 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single
 <Tabs>
   <TabItem value="todo-8" label="Todo #8" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition.py#L55-L56
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition.py#L55-L56
 ```
   </TabItem>
   <TabItem value="complete-8" label="Complete #8" default>
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single_party_compute/tiny_secret_addition_complete.py#L85-L93
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_single_party_compute/tiny_secret_addition_complete.py#L85-L93
 ```
   </TabItem>
 </Tabs>
@@ -263,7 +263,7 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/main/client_single
 Run the script to store the program, store secrets and compute on the program.
 
 ```bash
-cd client_single_party_compute
+cd core_concept_single_party_compute
 python3 tiny_secret_addition.py
 ```
 
@@ -275,14 +275,14 @@ You've successfully written your first single party Nada program, stored the pro
 
 - running other examples
 
-  - single party program examples in the [client_single_party_compute folder](https://github.com/NillionNetwork/nillion-python-starter/tree/main/client_single_party_compute)
-  - multi party examples in the [client_multi_party_compute folder](https://github.com/NillionNetwork/nillion-python-starter/tree/main/client_multi_party_compute)
-  - permissioning secrets examples in the in the [permissions folder](https://github.com/NillionNetwork/nillion-python-starter/tree/main/permissions) for storing and retrieving permissioned secrets and revoking permissions
+  - single party program examples in the [core_concept_single_party_compute folder](https://github.com/NillionNetwork/nillion-python-starter/tree/dave-restructure/examples_and_tutorials/core_concept_single_party_compute)
+  - multi party examples in the [core_concept_multi_party_compute folder](https://github.com/NillionNetwork/nillion-python-starter/tree/dave-restructure/examples_and_tutorials/core_concept_multi_party_compute)
+  - permissioning secrets examples in the in the [permissions folder](https://github.com/NillionNetwork/nillion-python-starter/tree/dave-restructure/examples_and_tutorials/core_concept_permissions) for storing and retrieving permissioned secrets and revoking permissions
 
 - reading about [Nillion concepts](/concepts) and the [Nada Language](nada-lang)
 
 - learning how to interact with and manage programs, secrets, and permissions on the Nillion Network with [Nillion Client](/nillion-client)
-- solving the [millionaires problem](/multi-party-computation#classic-scenario-the-millionaires-problem) in the [millionaires_problem_example folder](https://github.com/NillionNetwork/nillion-python-starter/tree/main/millionaires_problem_example)
+- solving the [millionaires problem](/multi-party-computation#classic-scenario-the-millionaires-problem) in the [millionaires_problem_example folder](https://github.com/NillionNetwork/nillion-python-starter/tree/dave-restructure/examples_and_tutorials/millionaires_problem_example)
 
 ### Solve the millionaires problem
 

--- a/docs/retrieve-secret.md
+++ b/docs/retrieve-secret.md
@@ -11,7 +11,7 @@ Retrieve secret strings, integers, and arrays from the network.
 Retrieve and decode a stored secret string
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_store_and_retrieve_secrets/store_and_retrieve_blob.py#L39-L45
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_store_and_retrieve_secrets/store_and_retrieve_blob.py#L39-L45
 ```
 
 ## Retrieve a SecretInteger
@@ -19,5 +19,5 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/e
 Retrieve a stored secret integer
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_store_and_retrieve_secrets/store_and_retrieve_integer.py#L37-L41
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_store_and_retrieve_secrets/store_and_retrieve_integer.py#L37-L41
 ```

--- a/docs/retrieve-secret.md
+++ b/docs/retrieve-secret.md
@@ -11,7 +11,7 @@ Retrieve secret strings, integers, and arrays from the network.
 Retrieve and decode a stored secret string
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_blob.py#L39-L45
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_store_and_retrieve_secrets/store_and_retrieve_blob.py#L39-L45
 ```
 
 ## Retrieve a SecretInteger
@@ -19,13 +19,5 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/main/store_and_ret
 Retrieve a stored secret integer
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_integer.py#L37-L41
-```
-
-## Retrieve a SecretArray
-
-Retrieve a stored secret array of integers
-
-```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_array.py#L45-L60
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_store_and_retrieve_secrets/store_and_retrieve_integer.py#L37-L41
 ```

--- a/docs/store-secrets.md
+++ b/docs/store-secrets.md
@@ -9,7 +9,7 @@ Check out the [store_secrets](/python-client-reference#py_nillion_client.Nillion
 Store a SecretBlob, a UTF-8 encoded secret string
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_store_and_retrieve_secrets/store_and_retrieve_blob.py#L15-L39
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_store_and_retrieve_secrets/store_and_retrieve_blob.py#L15-L39
 ```
 
 ## Store a SecretInteger
@@ -17,5 +17,5 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/e
 Store a single SecretInteger
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_store_and_retrieve_secrets/store_and_retrieve_integer.py#L15-L37
+https://github.com/NillionNetwork/nillion-python-starter/blob/main/examples_and_tutorials/core_concept_store_and_retrieve_secrets/store_and_retrieve_integer.py#L15-L37
 ```

--- a/docs/store-secrets.md
+++ b/docs/store-secrets.md
@@ -9,7 +9,7 @@ Check out the [store_secrets](/python-client-reference#py_nillion_client.Nillion
 Store a SecretBlob, a UTF-8 encoded secret string
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_blob.py#L15-L39
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_store_and_retrieve_secrets/store_and_retrieve_blob.py#L15-L39
 ```
 
 ## Store a SecretInteger
@@ -17,13 +17,5 @@ https://github.com/NillionNetwork/nillion-python-starter/blob/main/store_and_ret
 Store a single SecretInteger
 
 ```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_integer.py#L15-L37
-```
-
-## Store a SecretArray
-
-Stores an array, a list of values with the SecretInteger type
-
-```python reference showGithubLink
-https://github.com/NillionNetwork/nillion-python-starter/blob/main/store_and_retrieve_secrets/store_and_retrieve_array.py#L15-L45
+https://github.com/NillionNetwork/nillion-python-starter/blob/dave-restructure/examples_and_tutorials/core_concept_store_and_retrieve_secrets/store_and_retrieve_integer.py#L15-L37
 ```

--- a/sidebars.js
+++ b/sidebars.js
@@ -101,7 +101,7 @@ const sidebars = {
                     {
                       type: 'link',
                       label: 'Permissions Examples',
-                      href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/main/permissions',
+                      href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/dave-restructure/examples_and_tutorials/core_concept_permissions',
                     },
                   ],
                 },
@@ -116,17 +116,17 @@ const sidebars = {
                     {
                       type: 'link',
                       label: 'Single Party Examples',
-                      href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/main/client_single_party_compute',
+                      href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/dave-restructure/examples_and_tutorials/core_concept_single_party_compute',
                     },
                     {
                       type: 'link',
                       label: 'Multi Party Examples',
-                      href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/main/client_multi_party_compute',
+                      href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/dave-restructure/examples_and_tutorials/core_concept_multi_party_compute',
                     },
                     {
                       type: 'link',
                       label: 'Millionaires Problem',
-                      href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/main/millionaires_problem_example',
+                      href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/dave-restructure/examples_and_tutorials/millionaires_problem_example',
                     },
                   ],
                 },

--- a/sidebars.js
+++ b/sidebars.js
@@ -101,7 +101,7 @@ const sidebars = {
                     {
                       type: 'link',
                       label: 'Permissions Examples',
-                      href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/dave-restructure/examples_and_tutorials/core_concept_permissions',
+                      href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/main/examples_and_tutorials/core_concept_permissions',
                     },
                   ],
                 },
@@ -116,17 +116,17 @@ const sidebars = {
                     {
                       type: 'link',
                       label: 'Single Party Examples',
-                      href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/dave-restructure/examples_and_tutorials/core_concept_single_party_compute',
+                      href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/main/examples_and_tutorials/core_concept_single_party_compute',
                     },
                     {
                       type: 'link',
                       label: 'Multi Party Examples',
-                      href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/dave-restructure/examples_and_tutorials/core_concept_multi_party_compute',
+                      href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/main/examples_and_tutorials/core_concept_multi_party_compute',
                     },
                     {
                       type: 'link',
                       label: 'Millionaires Problem',
-                      href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/dave-restructure/examples_and_tutorials/millionaires_problem_example',
+                      href: 'https://github.com/NillionNetwork/nillion-python-starter/tree/main/examples_and_tutorials/millionaires_problem_example',
                     },
                   ],
                 },


### PR DESCRIPTION
put all examples into a `examples_and_tutorials/core_concept_*` folder

goes along with Restructure for DevEx - https://github.com/NillionNetwork/nillion-python-starter/pull/21

