### PR TITLE
Add blurb explaining the `port` that `nillion-devnet` runs on

### DIFF
--- a/docs/nillion-devnet.md
+++ b/docs/nillion-devnet.md
@@ -10,6 +10,8 @@ The `nillion-devnet` tool creates a Nillion network devnet that you can interact
 
 <FoundryInstallation/>
 
+**Note**: `nillion-devnet` runs on port `61391`. If you have another program running on that port, you can kill that program with `kill -9 $(lsof -t -i:61391)`.
+
 ### Run Devnet
 
 ```bash


### PR DESCRIPTION
# Overview 

When running through the examples, I had something running on that port & it took me a while to figure out what port the `devnet` is actually running on. Would be cool to include this info in `nillion-devnet` CLI's help message as well.