### PR TITLE
Change name of quickstart program to match tutorial

### DIFF
--- a/docs/python-quickstart.md
+++ b/docs/python-quickstart.md
@@ -288,7 +288,7 @@ We will write the following code in the `quickstart/client_code/secret_addition.
     ```python
     # 3. Pay for and store the program
     # Set the program name and path to the compiled program
-    program_name = "secret_addition_complete"
+    program_name = "secret_addition"
     program_mir_path = f"../nada_quickstart_programs/target/{program_name}.nada.bin"
 
     # Create payments config, client and wallet


### PR DESCRIPTION
The tutorial does not refer to the program name as `secret_addition_complete`, but as `secret_addition`. This place in the code breaks right now if you're following the tutorial.