### PR TITLE
add feedback per page feature

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -127,6 +127,18 @@ const config = {
         },
       },
     }),
+    plugins: [
+      [
+          'docusaurus-pushfeedback',{
+              project: '0zdbombk5w',
+              modalTitle: 'Nillion Docs Feedback',
+              messagePlaceholder: 'Let us know how we can improve this page of the Nillion docs.',
+              hideEmail: true,
+              sendButtonText: 'Send to the Nillion team',
+              buttonStyle: "dark",
+          }
+      ]
+    ],
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mdx-js/react": "^3.0.0",
         "ag-grid-react": "^32.0.1",
         "clsx": "^2.0.0",
+        "docusaurus-pushfeedback": "^1.0.1",
         "docusaurus-theme-github-codeblock": "^2.0.2",
         "dotenv": "^16.4.4",
         "prism-react-renderer": "^2.3.0",
@@ -7050,6 +7051,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/docusaurus-pushfeedback": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/docusaurus-pushfeedback/-/docusaurus-pushfeedback-1.0.1.tgz",
+      "integrity": "sha512-pD9RvbKKivQmIcGrXfDD+UMlavK0yAt/OhhUG/pz8sdfgSU0Hx5AmlEc/xJAsEYj78aVSWX3SV6/XXoksudjDg==",
+      "peerDependencies": {
+        "@docusaurus/core": "3.x"
       }
     },
     "node_modules/docusaurus-theme-github-codeblock": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@mdx-js/react": "^3.0.0",
     "ag-grid-react": "^32.0.1",
     "clsx": "^2.0.0",
+    "docusaurus-pushfeedback": "^1.0.1",
     "docusaurus-theme-github-codeblock": "^2.0.2",
     "dotenv": "^16.4.4",
     "prism-react-renderer": "^2.3.0",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -20,6 +20,8 @@
   --ifm-color-primary-lightest: #ccccff;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --feedback-primary-color: blue;
+  --feedback-font-family: "TWKEverett";
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1243,7 +1243,7 @@
     "@docsearch/css" "3.6.0"
     algoliasearch "^4.19.1"
 
-"@docusaurus/core@3.3.2":
+"@docusaurus/core@3.3.2", "@docusaurus/core@3.x":
   version "3.3.2"
   resolved "https://registry.npmjs.org/@docusaurus/core/-/core-3.3.2.tgz"
   integrity sha512-PzKMydKI3IU1LmeZQDi+ut5RSuilbXnA8QdowGeJEgU8EJjmx3rBHNT1LxQxOVqNEwpWi/csLwd9bn7rUjggPA==
@@ -3970,6 +3970,11 @@ dns-packet@^5.2.2:
   integrity sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
+
+docusaurus-pushfeedback@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/docusaurus-pushfeedback/-/docusaurus-pushfeedback-1.0.1.tgz"
+  integrity sha512-pD9RvbKKivQmIcGrXfDD+UMlavK0yAt/OhhUG/pz8sdfgSU0Hx5AmlEc/xJAsEYj78aVSWX3SV6/XXoksudjDg==
 
 docusaurus-theme-github-codeblock@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
Add the feedback feature so community members can provide feedback for any page of the docs.

This will only submit once the url matches docs.nillion.com, so you can't submit feedback for the demo page.

Demo: https://nillion-docs-git-feature-feedback-nillion.vercel.app/
