### PR TITLE
Quickstart Small Fixes 

### DIFF
--- a/docs/_sdk-installation.mdx
+++ b/docs/_sdk-installation.mdx
@@ -24,7 +24,7 @@ nilup use latest
 nilup init
 ```
 
-Optionally enable `nilup` telemetry, providing your Ethereum wallet address. We collect this data to understand how the software is used, and to better assist you in case of issues.In doing this, you consent to the collection of telemetry data by the Nillion Network. While we will not collect any personal information, we still recommend using a new wallet address that cannot be linked to your identity by any third party.
+Optionally enable `nilup` telemetry, providing your Ethereum wallet address. We collect this data to understand how the software is used, and to better assist you in case of issues. In doing this, you consent to the collection of telemetry data by the Nillion Network. While we will not collect any personal information, we still recommend using a new wallet address that cannot be linked to your identity by any third party.
 For more information, check out our [privacy policy](https://nillion.com/privacy/).
 
 ```bash

--- a/docs/quickstart-blind-app.md
+++ b/docs/quickstart-blind-app.md
@@ -205,7 +205,7 @@ Now your cra-nillion app can use the nada program and the nada program binaries 
 3. Update programName to `secret_addition` so the cra-nillion repo reads your Nada program.
 
 ```ts
-// const programName = 'addition_simple';
+// const programName = 'addition_simple'; <-- Change the string
 const programName = "secret_addition";
 ```
 

--- a/docs/quickstart-blind-app.md
+++ b/docs/quickstart-blind-app.md
@@ -204,8 +204,9 @@ Now your cra-nillion app can use the nada program and the nada program binaries 
 
 3. Update programName to `secret_addition` so the cra-nillion repo reads your Nada program.
 
-```ts reference showGithubLink
-https://github.com/NillionNetwork/cra-nillion/blob/main/src/ComputePage.tsx#L13
+```ts
+// const programName = 'addition_simple';
+const programName = "secret_addition";
 ```
 
 :::tip

--- a/docs/quickstart-testnet.md
+++ b/docs/quickstart-testnet.md
@@ -8,7 +8,7 @@ Your blind app is currently running locally against the nillion-devnet. Let's co
 
 ## Update your .env file and test locally
 
-Update your .env values to point at the Nillion Testnet
+Update your `.env` values to point at the Nillion Testnet
 
 <ReactTestnetEnv/>
 


### PR DESCRIPTION
Was going through the quickstart and found a small discrepnancy. It says to update it to `simple_addition` but the code was just showing the former of  `addition_simple`

Previous:
![image](https://github.com/user-attachments/assets/f778d346-23c8-4fc3-9268-9bf0844dff5b)

Current PR:
- It removes the reference + is manual code. If you prefer the `reference showGithubLink` we can think of another method

![image](https://github.com/user-attachments/assets/4eae8273-22dc-448c-9680-d10050937a0b)

