### PR TITLE
Feat: footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -126,20 +126,77 @@ const config = {
           hideable: true,
         },
       },
+      footer: {
+        links: [
+          {
+            title: 'Community',
+            items: [
+              {
+                type: 'link',
+                label: 'Discord',
+                href: 'https://discord.com/invite/nillionnetwork',
+              },
+              {
+                type: 'link',
+                label: 'X (formerly Twitter)',
+                href: 'https://twitter.com/nillionnetwork',
+              },
+            ],
+          },
+          {
+            title: 'Builders',
+            items: [
+              {
+                type: 'link',
+                label: 'Github Discussions',
+                href: 'https://github.com/orgs/NillionNetwork/discussions',
+              },
+              {
+                type: 'link',
+                label: 'Builder Bounties',
+                href: 'https://github.com/NillionNetwork/builder-bounties',
+              },
+              {
+                type: 'link',
+                label: 'Report a Bug',
+                href: 'https://github.com/orgs/NillionNetwork/discussions/categories/bugs',
+              },
+            ],
+          },
+          {
+            title: 'More',
+            items: [
+              {
+                type: 'link',
+                label: 'Website',
+                href: 'https://nillion.com',
+              },
+              {
+                type: 'link',
+                label: 'Blog',
+                href: 'https://nillion.com/news',
+              },
+            ],
+          },
+        ],
+        copyright: `${new Date().getFullYear()} Nillion. All Rights Reserved.`,
+      },
     }),
-    plugins: [
-      [
-          'docusaurus-pushfeedback',{
-              project: '0zdbombk5w',
-              modalTitle: 'Nillion Docs Feedback',
-              messagePlaceholder: 'Let us know how we can improve this page of the Nillion docs.',
-              hideEmail: true,
-              sendButtonText: 'Send to the Nillion team',
-              buttonStyle: "dark",
-              hideScreenshotButton: true
-          }
-      ]
+  plugins: [
+    [
+      'docusaurus-pushfeedback',
+      {
+        project: '0zdbombk5w',
+        modalTitle: 'Nillion Docs Feedback',
+        messagePlaceholder:
+          'Let us know how we can improve this page of the Nillion docs.',
+        hideEmail: true,
+        sendButtonText: 'Send to the Nillion team',
+        buttonStyle: 'dark',
+        hideScreenshotButton: true,
+      },
     ],
+  ],
 };
 
 export default config;

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -92,19 +92,11 @@ const config = {
           },
           {
             href: 'https://github.com/NillionNetwork',
-            label: 'GitHub',
-            position: 'right',
-          },
-          {
-            href: 'https://github.com/orgs/NillionNetwork/discussions',
-            label: 'Discussions',
+            className: 'header-github',
             position: 'right',
           },
         ],
       },
-      // footer: {
-      //   copyright: `Copyright © ${new Date().getFullYear()} Nillion`,
-      // },
       prism: {
         theme: prismThemes.github,
         darkTheme: prismThemes.dracula,

--- a/sidebars.js
+++ b/sidebars.js
@@ -339,21 +339,6 @@ const sidebars = {
     },
     'limitations',
     {
-      type: 'link',
-      label: 'Builder Discussions',
-      href: 'https://github.com/orgs/NillionNetwork/discussions',
-    },
-    {
-      type: 'link',
-      label: 'Builder Bounties',
-      href: 'https://github.com/NillionNetwork/builder-bounties',
-    },
-    {
-      type: 'link',
-      label: 'Report a Bug',
-      href: 'https://github.com/orgs/NillionNetwork/discussions/categories/bugs',
-    },
-    {
       type: 'html',
       className: 'sidebar-title',
       value: 'Resources',
@@ -378,37 +363,6 @@ const sidebars = {
     'nucleus-builders-program',
     'technical-reports-and-demos',
     'glossary',
-    {
-      type: 'html',
-      className: 'sidebar-title',
-      value: 'Links',
-      defaultStyle: true,
-    },
-    {
-      type: 'link',
-      label: 'Website',
-      href: 'https://nillion.com',
-    },
-    {
-      type: 'link',
-      label: 'X (formerly Twitter)',
-      href: 'https://twitter.com/nillionnetwork',
-    },
-    {
-      type: 'link',
-      label: 'Discord',
-      href: 'https://discord.com/invite/nillionnetwork',
-    },
-    {
-      type: 'link',
-      label: 'Github',
-      href: 'https://github.com/NillionNetwork',
-    },
-    {
-      type: 'link',
-      label: 'Blog',
-      href: 'https://nillion.com/news',
-    },
   ],
   nadaByExampleSidebar: [
     {
@@ -451,7 +405,7 @@ const sidebars = {
         'nada-by-example/secret-data-type',
         'nada-by-example/public-data-type',
         'nada-by-example/literal-data-type',
-      ]
+      ],
     },
     {
       type: 'category',
@@ -474,7 +428,7 @@ const sidebars = {
         'nada-by-example/equality',
         'nada-by-example/if-else',
         'nada-by-example/reveal',
-      ]
+      ],
     },
     'nada-by-example/list-comprehensions',
     'nada-by-example/helper-function',
@@ -535,7 +489,7 @@ const sidebars = {
           type: 'link',
           label: 'Convolutional Neural Network',
           href: 'https://github.com/NillionNetwork/nada-ai/tree/main/examples/conv_net',
-        }
+        },
       ],
     },
     {
@@ -570,7 +524,7 @@ const sidebars = {
         },
       ],
     },
-  ]
+  ],
 };
 
 export default sidebars;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -21,7 +21,7 @@
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
   --feedback-primary-color: blue;
-  --feedback-font-family: "TWKEverett";
+  --feedback-font-family: 'TWKEverett';
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -74,4 +74,21 @@ h4 {
 
 .navbar__title {
   font-size: 30px;
+}
+
+[data-theme='dark'] .header-github:hover {
+  filter: invert(0.8);
+}
+
+.header-github:hover {
+  opacity: 0.6;
+}
+
+.header-github:before {
+  content: '';
+  width: 24px;
+  height: 24px;
+  display: flex;
+  background: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='white' d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E")
+    no-repeat;
 }


### PR DESCRIPTION
Added in the footer + relegated sidebar links that will free up real estate.
Also gave more free space at the top with the Github / Github Discussions. If we want to put Discussions back, we can. 

Previous:
<img width="1462" alt="image" src="https://github.com/user-attachments/assets/662c0c07-5d19-4afe-9859-747e1f65331a">

Current PR
<img width="1465" alt="image" src="https://github.com/user-attachments/assets/ff2a51c0-91ed-48e0-a6f2-58b6902bff1d">
