### PR TITLE
chore: sidebar hierachy + small changes to Python Quickstart

### DIFF
--- a/docs/python-quickstart.md
+++ b/docs/python-quickstart.md
@@ -416,6 +416,7 @@ We will write the following code within the `quickstart/client_code` directory i
    
    ```bash
    cd client_code
+   mv run_my_first_program.py secret_addition.py
    python3 secret_addition.py
    ```
    

--- a/docs/python-quickstart.md
+++ b/docs/python-quickstart.md
@@ -434,4 +434,4 @@ Congratulations, you've successfully written your first single party Nada progra
   - Tutorials:
     - [Voting schemes](https://github.com/NillionNetwork/python-examples/tree/main/examples_and_tutorials/voting_tutorial)
     - [Millionaire's tutorial](https://github.com/NillionNetwork/python-examples/tree/main/examples_and_tutorials/millionaires_problem_example)
-      <IframeVideo videoSrc="https://www.loom.com/embed/d77604f001be4293b1b0c72c67620071?sid=d8dba7d7-0643-47cf-bf44-8b8b33c18cd6"/>import Tabs from '@theme/Tabs';
+      <IframeVideo videoSrc="https://www.loom.com/embed/d77604f001be4293b1b0c72c67620071?sid=d8dba7d7-0643-47cf-bf44-8b8b33c18cd6"/>

--- a/sidebars.js
+++ b/sidebars.js
@@ -70,25 +70,6 @@ const sidebars = {
       defaultStyle: true,
     },
     'start-building',
-    'network-configuration',
-    {
-      type: 'category',
-      label: 'Nillion SDK and Tools',
-      link: {
-        type: 'doc',
-        id: 'nillion-sdk-and-tools',
-      },
-      items: [
-        'installation',
-        'nilup',
-        'nillion',
-        'nillion-devnet',
-        'node-key2peerid',
-        'nada',
-        'pynadac',
-        'nada-run',
-      ],
-    },
     {
       type: 'category',
       label: 'Nillion Clients',
@@ -195,6 +176,25 @@ const sidebars = {
         },
       ],
     },
+    {
+      type: 'category',
+      label: 'Nillion SDK and Tools',
+      link: {
+        type: 'doc',
+        id: 'nillion-sdk-and-tools',
+      },
+      items: [
+        'installation',
+        'nilup',
+        'nillion',
+        'nillion-devnet',
+        'node-key2peerid',
+        'nada',
+        'pynadac',
+        'nada-run',
+      ],
+    },
+    'network-configuration',
     {
       type: 'category',
       label: 'Nada Language',

--- a/sidebars.js
+++ b/sidebars.js
@@ -194,7 +194,6 @@ const sidebars = {
         'nada-run',
       ],
     },
-    'network-configuration',
     {
       type: 'category',
       label: 'Nada Language',
@@ -337,6 +336,7 @@ const sidebars = {
         },
       ],
     },
+    'network-configuration',
     'limitations',
     {
       type: 'html',


### PR DESCRIPTION
Hierachy Nitpick to make clients + SDK higher in sidebar hierachy + 
- Small chore to remove unnecessary Tab code at the bottom of Python Quickstart
- Missing instruction to `mv run_my_first_program.py secret_addition.py` for Python Quickstart

Previous:
<img width="308" alt="image" src="https://github.com/user-attachments/assets/07bed37b-a1b4-4044-ad73-67c999424467">

After:
<img width="301" alt="image" src="https://github.com/user-attachments/assets/95de97b7-c271-4521-b77d-e9efee81d0fa">
