### PR TITLE
chore: showcase info

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -62,7 +62,11 @@ import TabItem from '@theme/TabItem';
 
         :::
 
+        <div className="divider"/>
+
+
         <SdkInstallation />
+
 
         🎉 Great work! You've set up a WSL environment and installed Nillion within that environment. Before running a nillion command like `nillion-devnet`, `nada`, or `pynadac` make sure you are in a WSL environment by first running ubuntu:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
     </TabItem>
 
-    <TabItem value="windows-guide" label="Windows" default>
+    <TabItem value="windows-guide" label="Windows">
         ## Windows Guide
 
         Today Nillion SDK binaries are available for Mac and Linux. In order to install Nillion on a Windows machine, you'll need to first complete a 5 minute WSL developer environment setup. Follow the steps below to install WSL, set up your WSL developer environment, and install and use Nillion Linux binaries from a Windows machine.
@@ -69,7 +69,6 @@ import TabItem from '@theme/TabItem';
         ```
         ubuntu
         ```
-
 
     </TabItem>
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -63,6 +63,7 @@ import TabItem from '@theme/TabItem';
         :::
 
         <div className="divider"/>
+        ### Installation
 
 
         <SdkInstallation />

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -2,6 +2,10 @@ import ProjectsTable from '@site/src/components/ProjectsTable/index';
 
 # Awesome Projects
 
+:::info
+Some showcase examples use older Nillion SDK versions. For the latest code and approaches, refer to the [Javascript](./js-quickstart) + [Python](./python-client) Clients.
+:::
+
 A showcase of open source projects built on Nillion by the community
 
 <ProjectsTable/>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -98,3 +98,10 @@ h4 {
 [data-theme='dark'] .sidebar-title {
   border-bottom: solid rgb(96, 103, 112) 1px;
 }
+
+.divider {
+  width: 100%;
+  height: 1px;
+  background-color: #ccc;
+  margin: 20px 0;
+}


### PR DESCRIPTION
Done
- Add info box so developers know to follow the latest Examples

<img width="860" alt="image" src="https://github.com/user-attachments/assets/cb5c5cbe-eb87-4d8f-91ec-f09ee9f47fdb">

Small Cosmetics:
- Added Divider for windows for legibility.

![image](https://github.com/user-attachments/assets/46ec42cf-c3ad-4474-b373-72b56b2ebe97)
