### PR TITLE
Fix Incorrect Array Initialization with nillion.SecretArray

### DIFF
--- a/docs/python-client-reference.md
+++ b/docs/python-client-reference.md
@@ -854,7 +854,7 @@ import py_nillion_client as nillion
 
 sec_uinteger = nillion.SecretUnsignedInteger(1)
 sec_integer = nillion.SecretInteger(1)
-sec_array = nillion.SecretArray([
+sec_array = nillion.Array([
     nillion.SecretInteger(1),
     nillion.SecretInteger(2),
 ])


### PR DESCRIPTION
This PR corrects the instantiation of sec_array, which was incorrectly set to use nillion.SecretArray instead of the intended nillion.Array.