### PR TITLE
chore: older docs banner [No Merge]

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -134,7 +134,7 @@ const config = {
       announcementBar: {
         id: 'older_client_version',
         content:
-          'These docs are for the older versioned JS + Python Client.',
+          'These docs are for the older <a target="_blank" rel="noopener noreferrer" href="../js-client"> JS Client</a> and <a target="_blank" rel="noopener noreferrer" href="../python-client"> Python Client</a>',
         backgroundColor: '#4B4A96',
         textColor: '#fff',
         isCloseable: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -131,6 +131,14 @@ const config = {
         indexName: 'nillion_docs',
         searchPagePasitemapth: 'search',
       },
+      announcementBar: {
+        id: 'older_client_version',
+        content:
+          'These docs are for the older versioned JS + Python Client.',
+        backgroundColor: '#4B4A96',
+        textColor: '#fff',
+        isCloseable: true,
+      },
       docs: {
         sidebar: {
           hideable: true,


### PR DESCRIPTION
Snapshot current main branch so people can view the older JS / Python Client
<img width="1428" alt="image" src="https://github.com/user-attachments/assets/39b7b81c-b91b-41e5-b0ef-bab687e614e7">
