### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/aivm.md
+++ b/docs/aivm.md
@@ -209,7 +209,7 @@ Custom models must meet these requirements:
 
 ### Next Steps
 
-Now you can check out the [examples](https://github.com/NillionNetwork/nillion-aivm/tree/main/examples) folder and get started with your own fine-tuned nd custom models.
+Now you can check out the [examples](https://github.com/NillionNetwork/nillion-aivm/tree/main/examples) folder and get started with your own fine-tuned and custom models.
 
 You can try:
 

--- a/docs/first-steps.md
+++ b/docs/first-steps.md
@@ -2,7 +2,7 @@
 
 👋 Hey, welcome to [Nillion](https://docs.nillion.com/).
 
-This page will help you take your first steps (~30 mins) as a Nillion developer. Once you have completed them, fill out the form for your chance to claim your $20 prize - each week we will review the submissions and pick the best to recieve a prize 🎉
+This page will help you take your first steps (~30 mins) as a Nillion developer. Once you have completed them, fill out the form for your chance to claim your $20 prize - each week we will review the submissions and pick the best to receive a prize 🎉
 
 1. Star & fork either the [Python](https://github.com/NillionNetwork/nillion-python-starter) or [JavaScript](https://github.com/NillionNetwork/cra-nillion) quickstart repos (bonus points for both)
 

--- a/docs/nada-lang-programs.md
+++ b/docs/nada-lang-programs.md
@@ -26,7 +26,7 @@ The [`tiny_addition.py`](https://github.com/nillion-oss/nillion-python-starter/b
 
 <table><thead><tr><th width="162">Input name</th><th width="145">Input type</th><th>Party name</th></tr></thead><tbody><tr><td>`my_secret_1`</td><td>`SecretInteger`</td><td>`Nilla 🐶`</td></tr><tr><td>`my_secret_2`</td><td>`SecretInteger`</td><td>`Nilla 🐶`</td></tr></tbody></table>
 
-The program [`tiny_addition.py`](https://github.com/nillion-oss/nillion-python-starter/blob/main/programs/tiny_secret_addition_complete.py) returns an [Output](concepts.md#outputs) to a [Party](concepts.md#party). Only that party sees the output because it it of type `SecretInteger`.
+The program [`tiny_addition.py`](https://github.com/nillion-oss/nillion-python-starter/blob/main/programs/tiny_secret_addition_complete.py) returns an [Output](concepts.md#outputs) to a [Party](concepts.md#party). Only that party sees the output because it of type `SecretInteger`.
 
 <table>
   <thead>

--- a/docs/nada-numpy-introduction.md
+++ b/docs/nada-numpy-introduction.md
@@ -120,7 +120,7 @@ Finally, we need to produce the output. Since `NadaArray` is not a base Nada typ
     return res.output(parties[2], "my_output")
 ```
 
-In this case, we'll be invoking `res.output(parties[2], "my_output")` establishing that the output party will be `Party2`and the name of the output variable will be `"my_output"`.
+In this case, we'll be invoking `res.output(parties[2], "my_output")` establishing that the output party will be `Party2` and the name of the output variable will be `"my_output"`.
 
 With everything in place, we can build and test our program:
 
@@ -130,7 +130,7 @@ nada build
 
 ## Using Nada Numpy with Nillion Network
 
-After completing the program writing, we can upload it and interact with it in the network with the ease provided by Nada Numpy. For that, we use the Python Nillion Client. We can use the same complete code as for other examples. The only difference is how Nada Numpy allows to easily include arrays in our uploads to the Nillion Networ with the Nada Numpy client. We add the link to the [complete code](https://github.com/NillionNetwork/nada-algebra/blob/main/examples/broadcasting/main.py).
+After completing the program writing, we can upload it and interact with it in the network with the ease provided by Nada Numpy. For that, we use the Python Nillion Client. We can use the same complete code as for other examples. The only difference is how Nada Numpy allows to easily include arrays in our uploads to the Nillion Network with the Nada Numpy client. We add the link to the [complete code](https://github.com/NillionNetwork/nada-algebra/blob/main/examples/broadcasting/main.py).
 
 First, import the necessary modules:
 

--- a/docs/nada.md
+++ b/docs/nada.md
@@ -291,7 +291,7 @@ Run a program with the --metrics flag to retrieve detailed execution metrics of 
 - json: Outputs metrics in JSON format and saves it to a metrics.json file.
 - yaml: Outputs metrics in YAML format and saves it to a metrics.yaml file.
 
-For detailed information on the metrics reported, pleas, visit the [Nada Metrics](/nada-metrics) section.
+For detailed information on the metrics reported, please, visit the [Nada Metrics](/nada-metrics) section.
 
 #### Example metrics usage
 

--- a/docs/python-quickstart.md
+++ b/docs/python-quickstart.md
@@ -44,7 +44,7 @@ The [Nillion Python Starter repo](https://github.com/NillionNetwork/nillion-pyth
    source .venv/bin/activate
    ```
 
-5. Intall the requirements
+5. Install the requirements
    ```bash
    pip install --upgrade -r requirements.txt
    ```
@@ -430,7 +430,7 @@ Congratulations, you've successfully written your first single party Nada progra
   - Examples:
     - [single party examples](https://github.com/NillionNetwork/python-examples/tree/main/examples_and_tutorials/core_concept_single_party_compute)
     - [multi-party examples](https://github.com/NillionNetwork/python-examples/tree/main/examples_and_tutorials/core_concept_multi_party_compute)
-    - [storing and retrieving intergers and blobs](https://github.com/NillionNetwork/python-examples/tree/main/examples_and_tutorials/core_concept_store_and_retrieve_secrets)
+    - [storing and retrieving integers and blobs](https://github.com/NillionNetwork/python-examples/tree/main/examples_and_tutorials/core_concept_store_and_retrieve_secrets)
     - [using permissions](https://github.com/NillionNetwork/python-examples/tree/main/examples_and_tutorials/core_concept_permissions)
   - Tutorials:
     - [Voting schemes](https://github.com/NillionNetwork/python-examples/tree/main/examples_and_tutorials/voting_tutorial)

--- a/docs/start-building.md
+++ b/docs/start-building.md
@@ -8,7 +8,7 @@ The [Nada Quickstart](/quickstart-nada) will teach you how to create a Nada proj
 
 ## Build a Blind App
 
-This [Blind App Quickstart](/quickstart) is ideal for developers interested in **building frontends or fullstack web apps** on Nillion. This quickstart will guide you through writing a Nada program, storing the program on the Nillion Netowrk, and creating a blind web app lets you store secrets and run your Nada program in the browser.
+This [Blind App Quickstart](/quickstart) is ideal for developers interested in **building frontends or fullstack web apps** on Nillion. This quickstart will guide you through writing a Nada program, storing the program on the Nillion Network, and creating a blind web app lets you store secrets and run your Nada program in the browser.
 
 ## Connect a backend to Nillion
 


### PR DESCRIPTION
This pull request addresses and corrects several typographical errors across the following documentation files:

- **`aivm.md`**
- **`first-steps.md`**
- **`nada-lang-programs.md`**
- **`nada-numpy-introduction.md`**
- **`nada.md`**
- **`python-quickstart.md`**
- **`start-building.md`**

These revisions are aimed at improving the overall clarity and accuracy of the documentation.