### PR TITLE
Spelling and Grammar Corrections

### DIFF
--- a/docs/aivm.md
+++ b/docs/aivm.md
@@ -209,7 +209,7 @@ Custom models must meet these requirements:
 
 ### Next Steps
 
-Now you can check out the [examples](https://github.com/NillionNetwork/nillion-aivm/tree/main/examples) folder and get started with your own fine-tuned nd custom models.
+Now you can check out the [examples](https://github.com/NillionNetwork/nillion-aivm/tree/main/examples) folder and get started with your own fine-tuned and custom models.
 
 You can try:
 

--- a/docs/data-wars.md
+++ b/docs/data-wars.md
@@ -1,6 +1,6 @@
 # Data Wars: Community Ranks
 
-This is not the allowlist you are looking you're looking for. Join the multi-week [Nillion bootcamp](https://zealy.io/cw/nillion) to be fully onboarded into the Nil Army. Every week you will have the potential to be whitelisted for the upcoming Nillion Blindfolded PFP NFT release.
+This is not the allowlist you are looking for. Join the multi-week [Nillion bootcamp](https://zealy.io/cw/nillion) to be fully onboarded into the Nil Army. Every week you will have the potential to be whitelisted for the upcoming Nillion Blindfolded PFP NFT release.
 
 ![An image from the static](/img/data-wars.png)
 

--- a/docs/first-steps.md
+++ b/docs/first-steps.md
@@ -2,7 +2,7 @@
 
 👋 Hey, welcome to [Nillion](https://docs.nillion.com/).
 
-This page will help you take your first steps (~30 mins) as a Nillion developer. Once you have completed them, fill out the form for your chance to claim your $20 prize - each week we will review the submissions and pick the best to recieve a prize 🎉
+This page will help you take your first steps (~30 mins) as a Nillion developer. Once you have completed them, fill out the form for your chance to claim your $20 prize - each week we will review the submissions and pick the best to receive a prize 🎉
 
 1. Star & fork either the [Python](https://github.com/NillionNetwork/nillion-python-starter) or [JavaScript](https://github.com/NillionNetwork/cra-nillion) quickstart repos (bonus points for both)
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -16,7 +16,7 @@ layout:
 
 #### Information-theoretic security (ITS)
 
-Information-theoretic security is a measure of security that doesn't depend on computational hardness assumptions. ITS guarantees security even against adversaries with unlimited computational power. This type of security is achieved by ensuring that the information required to break the encryption is not present in the cipher text. A classic example of ITS is a one-time pad cipher, which is provably unbreakable as long as the key is truly random, never reused, and kept secret.
+Information-theoretic security is a measure of security that doesn't depend on computational hardness assumptions. ITS guarantees security even against adversaries with unlimited computational power. This type of security is achieved by ensuring that the information required to break the encryption is not present in the ciphertext. A classic example of ITS is a one-time pad cipher, which is provably unbreakable as long as the key is truly random, never reused, and kept secret.
 
 #### Linear Secret Sharing Scheme (LSSS)
 
@@ -44,7 +44,7 @@ Preprocessing refers to a computation that is executed before one is given the i
 
 Each online protocol requires a different amount and type of preprocessing elements. A "preprocessing service" inside each node is responsible for calculating these preprocessing elements and makes them available to the Nillion VM. The "preprocessing service" will try to make sure that there are enough available preprocessing elements in the node at any time.
 
-Computing these preprocessing elements usually requires an MPC protocol. This is because there needs to be some syncrhonisation in the way these elements are created and used by the nodes.
+Computing these preprocessing elements usually requires an MPC protocol. This is because there needs to be some synchronisation in the way these elements are created and used by the nodes.
 
 #### Privacy-enhancing technologies (PETs)
 

--- a/docs/nada-libraries.md
+++ b/docs/nada-libraries.md
@@ -14,7 +14,7 @@ The Nillion Network leverages [Nada](/nada-lang) for defining programs. We are d
 
 ## Nada AI
 
-[nada-ai](/nada-ai-introduction) is a Python library for performing ML/AI tasks using Nada DSL and the Nillion Network. It offers an intuitive interface and seamless integration with ML frameworks like PyTorch and Sci-kit learn. Key Features include
+[nada-ai](/nada-ai-introduction) is a Python library for performing ML/AI tasks using Nada DSL and the Nillion Network. It offers an intuitive interface and seamless integration with ML frameworks like PyTorch and Scikit-learn. Key Features include
 
 - Exporting Model State: Integrates with models from existing ML frameworks, making it easy to export them to the Nillion network for use in Nada programs.
 - AI Modules: Provides a PyTorch-like interface to create ML models in Nada by stacking pre-built common components, with the option to create custom components.

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -17,4 +17,4 @@ Developers can use Nillion to build secure, [high value data](high-value-data.md
 <br/>
 <LinkButton text="Learn about Nillion" link="/what-is-nillion"/>
 
-<LinkButton text="Build a Blind App"link="/quickstart"/>
+<LinkButton text="Build a Blind App" link="/quickstart"/>


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.
Description correction:

Corrected "nd" to "and".
Corrected "recieve" to "receive".
Corrected "cipher text" to "ciphertext".
Corrected "syncrhonisation" to "synchronisation".
Corrected "Sci-kit learn" to "Scikit-learn".
Corrected "Applink" to "App link" and much more.
Please review the changes and let me know if any additional changes are needed before merging.