### PR TITLE
docs: fix typos

### DIFF
--- a/docs/aivm.md
+++ b/docs/aivm.md
@@ -209,7 +209,7 @@ Custom models must meet these requirements:
 
 ### Next Steps
 
-Now you can check out the [examples](https://github.com/NillionNetwork/nillion-aivm/tree/main/examples) folder and get started with your own fine-tuned nd custom models.
+Now you can check out the [examples](https://github.com/NillionNetwork/nillion-aivm/tree/main/examples) folder and get started with your own fine-tuned and custom models.
 
 You can try:
 

--- a/docs/data-wars.md
+++ b/docs/data-wars.md
@@ -1,6 +1,6 @@
 # Data Wars: Community Ranks
 
-This is not the allowlist you are looking you're looking for. Join the multi-week [Nillion bootcamp](https://zealy.io/cw/nillion) to be fully onboarded into the Nil Army. Every week you will have the potential to be whitelisted for the upcoming Nillion Blindfolded PFP NFT release.
+This is not the allowlist you are looking for. Join the multi-week [Nillion bootcamp](https://zealy.io/cw/nillion) to be fully onboarded into the Nil Army. Every week you will have the potential to be whitelisted for the upcoming Nillion Blindfolded PFP NFT release.
 
 ![An image from the static](/img/data-wars.png)
 

--- a/docs/nada.md
+++ b/docs/nada.md
@@ -291,7 +291,7 @@ Run a program with the --metrics flag to retrieve detailed execution metrics of 
 - json: Outputs metrics in JSON format and saves it to a metrics.json file.
 - yaml: Outputs metrics in YAML format and saves it to a metrics.yaml file.
 
-For detailed information on the metrics reported, pleas, visit the [Nada Metrics](/nada-metrics) section.
+For detailed information on the metrics reported, please, visit the [Nada Metrics](/nada-metrics) section.
 
 #### Example metrics usage
 


### PR DESCRIPTION
Fixed few typos for clarity in the documentation. Hope this helps.