### PR TITLE
fix: Correct domain name for photon2 bootnode

### DIFF
--- a/src/components/Networks/network-info-photon2.js
+++ b/src/components/Networks/network-info-photon2.js
@@ -7,7 +7,7 @@ export const NetworkConfig = {
     bootnode: {
       name: 'NILLION_BOOTNODE_MULTIADDRESS',
       value:
-        'https://node-1.photon2.nillion-network-nilogy.xyz:14311',
+        'https://node-1.photon2.nillion-network.nilogy.xyz:14311',
     },
     websocket: {
       name: 'NILLION_BOOTNODE_WEBSOCKET',


### PR DESCRIPTION
There's a minor mistake in the domain. A `.` should separate `nillion-network` and `nilogy.xyz` not a `-`.