### PR TITLE
Fix typos: js-client-hooks.md

### DIFF
--- a/docs/js-client-hooks.md
+++ b/docs/js-client-hooks.md
@@ -4,9 +4,9 @@ import DocCardList from '@theme/DocCardList';
 Hooks are functions that help you easily read/write into Nillion network and interact with Nada Programs. Our [examples/nextjs](https://github.com/NillionNetwork/client-ts/tree/main/examples-nextjs) have all of these as components to better understand how to interact with them.
 
 To best understand how Nillion functions, it provides two main focuses:
-1. Storage of [values](./js-client-hooks-values.md) and retreiving them
+1. Storage of [values](./js-client-hooks-values.md) and retrieving them
 2. Blind [computation](./js-client-hooks-compute.md) powered by MPC with Nada Programs. 
 
-[Permissions](./js-client-hooks-permissions.md) are added ontop of the network to allow/restrict who can interact with the storage and compute. 
+[Permissions](./js-client-hooks-permissions.md) are added on top of the network to allow/restrict who can interact with the storage and compute. 
 
 <DocCardList/>


### PR DESCRIPTION
### Description of Changes:
1. **Fixed typo in "retreiving"**:
   - Replaced with the correct spelling "retrieving".
   
2. **Fixed "ontop" typo**:
   - Split into two separate words "on top" for correct usage.

### Reason for Changes:
- These corrections address spelling mistakes to improve readability and accuracy of the text in the code.
