### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/nillion-devnet.md
+++ b/docs/nillion-devnet.md
@@ -14,12 +14,12 @@ Options:
           [default: 3]
 
   -c, --cluster-id <CLUSTER_ID>
-          The uuid of the cluster.
+          The UUID of the cluster.
 
-          A random uuid will be used if none is provided, honoring the --seed parameter.
+          A random UUID will be generated if none is provided, respecting the --seed parameter.
 
   -d, --state-directory <STATE_DIRECTORY>
-          The directory where the node's states is stored.
+          The directory where the nodes' state is stored.
 
           A temporary directory will be used if none is provided.
 
@@ -29,7 +29,7 @@ Options:
           If none is provided, node keys and the cluster id will be randomized.
 
   -p, --prime-bits <PRIME_BITS>
-          The number of bits in the prime number to be used
+          The number of bits for the prime number to be used.
 
           [default: 256]
 
@@ -52,7 +52,7 @@ Running a local devnet outputs values you can use to run nillion against your lo
 - devnet id
 - blockchain node endpoint
 - node ids
-- wallet keys: 14 private keys written to a file
+- Wallet keys: 14 private keys are written to a file in the specified directory or a temporary one.
 - payment configuration (blockchain info) written to a file
   - blockchain_rpc_endpoint
   - chain_id
@@ -61,7 +61,7 @@ Running a local devnet outputs values you can use to run nillion against your lo
 - bootnode
 - websocket
 
-### Spin down local devnet
+### Stop the local devnet
 
 To stop the local devnet, run
 


### PR DESCRIPTION


This pull request addresses several typos and stylistic improvements in the `nillion-devnet.md` file. The changes enhance clarity, fix grammatical issues, and align terminology with standard usage. Key updates include:  

1. **Option Descriptions:**
   - Corrected "uuid" to "UUID" for standard capitalization. 
   - Rephrased "A random uuid will be used..." to "A random UUID will be generated..." for improved readability and accuracy.
   - Updated "The directory where the node's states is stored." to "The directory where the nodes' state is stored." to fix plural inconsistency.
   - Modified "The number of bits in the prime number to be used." to "The number of bits for the prime number to be used." for natural phrasing.

2. **Devnet Outputs:**
   - Clarified where wallet keys are stored by specifying, "written to a file in the specified directory or a temporary one."
   - Suggested explaining the abbreviation "sc" (e.g., "smart contract") for better understanding.

3. **Stylistic Adjustments:**
   - Updated "Spin down local devnet" to "Stop the local devnet" to align with standard technical terminology.

---

**Status:**  
- All changes are inline with the contributing guidelines.  
- No breaking changes were introduced.  
- Ready to merge.  

**Suggestion:** Consider adding an explanation for "sc" in future documentation revisions to improve clarity.  

--- 

Let me know if further adjustments are needed! 😊
