### PR TITLE
Fix typos in quickstart and installation documentation 

### DIFF
--- a/docs/_quickstart-compile-run-test.mdx
+++ b/docs/_quickstart-compile-run-test.mdx
@@ -2,7 +2,7 @@ Use the <strong>[`nada`](/nada)</strong> tool to compile, run and test the progr
 
 1. Add your program to `nada-project.toml` config file
 
-   For the nada tool to know about our program, we need to add the following to the to the `nada-project.toml` config file.
+   For the nada tool to know about our program, we need to add the following to the `nada-project.toml` config file.
    ```bash
    [[programs]]
    path = "src/secret_addition.py"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,7 +54,7 @@ import TabItem from '@theme/TabItem';
         Now that your WSL development environment is set up, you can install the Nillion SDK and Tools.
 
         :::info
-        Make sure to install Nillion within **a new Ubuntu terminal.** Either open a Ubuntu terminal, or from your Windows PowerShell terminal, first run Ubuntu:
+        Make sure to install Nillion within **a new Ubuntu terminal.** Either open an Ubuntu terminal, or from your Windows PowerShell terminal, first run Ubuntu:
 
         ```
         ubuntu


### PR DESCRIPTION
This pull request corrects minor typos in the following documentation files:  

**Summary of Changes:**  
1. Removed duplicate wording in `_quickstart-compile-run-test.mdx`.  
   - Corrected: "add the following to the to the" → "add the following to the".  
2. Adjusted the indefinite article usage in `installation.md`.  
   - Corrected: "a Ubuntu terminal" → "an Ubuntu terminal".  

**Files Modified:**  
- `docs/_quickstart-compile-run-test.mdx`  
- `docs/installation.md`  

These fixes improve the clarity and grammatical accuracy of the documentation.  
