### PR TITLE
Update js-client-hooks-other.md

### DIFF
--- a/docs/js-client-hooks-other.md
+++ b/docs/js-client-hooks-other.md
@@ -25,7 +25,7 @@ nillion.client.XXX // whatever you want to use from the client.
 
 ```
 
-Below is the source code for refernce
+Below is the source code for reference
 
 ```tsx reference showGithubLink
 https://github.com/NillionNetwork/client-ts/blob/main/client-react-hooks/src/use-nillion.ts


### PR DESCRIPTION
update with minor typos at the **Nillion Clients** - **JavaScript Client** - **Hooks** - **Other** [_page_](https://docs.nillion.com/js-client-hooks-other)

fix typo from **"refernce"** to **"reference"**

![image](https://github.com/user-attachments/assets/4b57c9fb-2a9b-4316-b2df-df6bae415195)
