### PR TITLE
chore: fix nildb-api.yaml

### DIFF
--- a/apispec/nildb-api.yaml
+++ b/apispec/nildb-api.yaml
@@ -168,7 +168,7 @@ components:
                   - $ref: '#/components/schemas/QueryVariable'
                   - $ref: '#/components/schemas/QueryArrayVariable'
             pipeline:
-              description: An query's execution pipline defined as an array of objects
+              description: An query's execution pipeline defined as an array of objects
               type: array
               items:
                 type: object


### PR DESCRIPTION
# Chore: Fix Typo in nildb-api.yaml

## Description
Corrected a typo:
- Changed "pipline" to "pipeline" in the description of the `pipeline` property.

