### PR TITLE
fix: update sdk installation commands

### DIFF
--- a/docs/_sdk-installation.mdx
+++ b/docs/_sdk-installation.mdx
@@ -16,6 +16,6 @@ You should see an output with the versions of `nilup` and `nillion` installed.
 #### Install the latest Nillion SDK version
 
 ```
-nillion install latest
-nillion use latest
+nilup install latest
+nilup use latest
 ```


### PR DESCRIPTION
Update the SDK commands with `nillion`:

```
nillion install latest
nillion use latest
```

With the correct ones using `nilup`:

```
nilup install latest
nilup use latest
```