### PR TITLE
Fix Typo: Correct "pipline" to "pipeline" in API Documentation

### DIFF
--- a/apispec/nildb/queries.openapi.yaml
+++ b/apispec/nildb/queries.openapi.yaml
@@ -29,7 +29,7 @@ components:
                   - $ref: '#/components/schemas/QueryVariable'
                   - $ref: '#/components/schemas/QueryArrayVariable'
             pipeline:
-              description: An query's execution pipline defined as an array of objects
+              description: An query's execution pipeline defined as an array of objects
               type: array
               items:
                 type: object

--- a/docs/api/nildb/get-queries.api.mdx
+++ b/docs/api/nildb/get-queries.api.mdx
@@ -158,7 +158,7 @@ List account queries
                         },
                         pipeline: {
                           description:
-                            "An query's execution pipline defined as an array of objects",
+                            "An query's execution pipeline defined as an array of objects",
                           type: 'array',
                           items: { type: 'object' },
                         },


### PR DESCRIPTION


Description:  
This pull request fixes a typo in the API documentation and OpenAPI spec files, changing "pipline" to the correct spelling "pipeline" in the description of the query execution pipeline. This improves clarity and accuracy in both the OpenAPI YAML and the related MDX documentation. No functional changes were made.