### PR TITLE
docs: add encryption to quickstart guide

### DIFF
--- a/docs/build/private-storage/quickstart.md
+++ b/docs/build/private-storage/quickstart.md
@@ -212,20 +212,41 @@ const collection = {
   type: 'owned', // Every document in the collection will be user-owned
   name: 'User Profile Collection',
   schema: {
-    $schema: 'http://json-schema.org/draft-07/schema#',
-    type: 'array',
-    uniqueItems: true,
-    items: {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'array',
+      uniqueItems: true,
+      items: {
       type: 'object',
       properties: {
-        _id: { type: 'string', format: 'uuid' },
-        name: { type: 'string' },
-        email: { type: 'string', format: 'email' },
-        phone: { type: 'string' },
+          _id: { type: 'string', format: 'uuid' },
+          name: { type: 'string' }, // name will not be secret shared
+          email: { // email will be secret shared
+            type: "object",
+            properties: {
+              "%share": {
+                type: "string"
+              }
+            },
+            required: [
+              "%share"
+            ]
+          },
+          phone: { // email will be secret shared
+            type: "object",
+            properties: {
+              "%share": {
+                type: "string"
+              }
+            },
+            required: [
+              "%share"
+            ]
+          },
       },
       required: ['_id', 'name', 'email'],
+      },
     },
-  },
+  };
 };
 ```
 

--- a/docs/build/private-storage/quickstart.md
+++ b/docs/build/private-storage/quickstart.md
@@ -255,6 +255,9 @@ try {
 const user = await SecretVaultUserClient.from({
   baseUrls: config.NILDB_NODES,
   keypair: userKeypair,
+  blindfold: {
+    operation: "store"
+  }
 });
 ```
 
@@ -269,11 +272,16 @@ const delegation = NucTokenBuilder.extending(builder.rootToken)
   .build(builderKeypair.privateKey());
 
 // User's private data
+// %allot indicates that the client should encrypt this data
 const userPrivateData = {
   _id: randomUUID(),
   name: 'Steph',
-  email: 'steph@example.com',
-  phone: '+1-555-0123',
+  email: {
+    "%allot": 'steph@example.com'
+  },
+  phone: {
+    "%allot": '+1-555-0123'
+  },
 };
 
 // User uploads data and grants builder limited access


### PR DESCRIPTION
- In `Step 5`, adds secret sharing to `email` and `phone` fields
- In `Step 7`, adds `blindfold` configuration
- In `Step 8`, adds private data fields