### PR TITLE
fix: clarify mongodb queries

### DIFF
--- a/docs/build/private-storage/overview.md
+++ b/docs/build/private-storage/overview.md
@@ -130,7 +130,8 @@ Users can grant and revoke permissions at any time. Each document maintains its 
 
 ### Query System
 
-MongoDB-style aggregation pipelines with stages like `$match`, `$group`, and `$count` are supported. Queries can operate on encrypted data without full decryption and support variables for parameterization.
+MongoDB-style aggregation pipelines are supported, including stages such as `$match`, `$group`, `$count`, `$lookup`, and `$project`.
+Queries can operate on encrypted data without full decryption and support variables for parameterization.
 
 **Query Variables**
 Allow parameterization of saved queries using JSONPath syntax to specify substitution points, enabling reusable query templates.

--- a/docs/build/private-storage/quickstart.md
+++ b/docs/build/private-storage/quickstart.md
@@ -231,7 +231,7 @@ const collection = {
               "%share"
             ]
           },
-          phone: { // email will be secret shared
+          phone: { // phone will be secret shared
             type: "object",
             properties: {
               "%share": {


### PR DESCRIPTION
- Add `$lookup` 
- Fixes typo in Quickstart guide